### PR TITLE
Update caldgemm_cuda.cu

### DIFF
--- a/caldgemm_cuda.cu
+++ b/caldgemm_cuda.cu
@@ -300,7 +300,8 @@ int caldgemm_cuda::ExecuteKernels(caldgemm::DGEMMPrepareAndExecuteTask& Task, in
 	CUDAKernel <<<blocks, threads, 0, cuda_command_queues[Task.device][Task.j]>>> (cbuffer, abuffer, bbuffer, height1, height2, width, Alpha, Beta, pitch);
 #else
         cublasSetStream(cublas_handles[Task.device], cuda_command_queues[Task.device][Task.j]);
-        cublasDgemm(cublas_handles[Task.device],CUBLAS_OP_T,CUBLAS_OP_N,height1,height2,width,&Alpha,bbuffer,width,abuffer,width,&Beta,cbuffer,pitch);
+        cublasDgemm(cublas_handles[Task.device],(TransposeB?CUBLAS_OP_T:CUBLAS_OP_N),(TransposeA?CUBLAS_OP_T:CUBLAS_OP_N),height1,height2,width, \
+                    &Alpha,bbuffer,(TransposeB?width:height1),abuffer,(TransposeA?height2:width),&Beta,cbuffer,pitch);
 #endif
 	CHKRET(cudaGetLastError(), "CUDA Kernel Execution");
 
@@ -400,16 +401,21 @@ int caldgemm_cuda::DGEMM_prepare_backend(size_t k, int j, unsigned int num_devic
 		}
 
 		if (Config->Debug) fprintf(STD_OUT, "Transfer A to GPU: region %d x %d\n", (int) width, (int) height);
+#ifndef CALDGEMM_CUDA_CUBLAS
 		CHKRET(cudaMemcpy2DAsync(dest_buffer_tmp, width, src_ptr, pitch * sizeof(double), width, height, cudaMemcpyHostToDevice, cuda_command_queues[num_device][j]), "Copying A to device");
+#else
+		CHKRET(cudaMemcpy2DAsync(dest_image, width, src_ptr, pitch * sizeof(double), width, height, cudaMemcpyHostToDevice, cuda_command_queues[num_device][j]), "Copying A to device");
+#endif
 		if (Config->Debug && Config->VerboseTiming) cudaStreamSynchronize(cuda_command_queues[num_device][j]);
 
+#ifndef CALDGEMM_CUDA_CUBLAS
 		dim3 threads(GROUP_SIZE_X, GROUP_SIZE_Y), blocks(GROUP_COUNT_X, GROUP_COUNT_Y);
 		int arg_transpose = TransposeA;
 		size_t arg_width = width / sizeof(double), arg_height = height;
 		if (Config->Debug) fprintf(STD_OUT, "Conversion Kernel A: x %d y %d (t: %d)\n", (int) arg_width, (int) arg_height, arg_transpose);
 		CUDAConversionKernel <<<blocks, threads, 0, cuda_command_queues[num_device][j]>>> ((double*) dest_buffer_tmp, (double*) dest_image, arg_width, arg_height, arg_transpose);
 		CHKRET(cudaGetLastError(), "CUDA Conversion Kernel Execution");
-		
+#endif
 		CHKRET(cudaEventRecord(cuda_conversion_events[num_device][0], cuda_command_queues[num_device][j]), "Recording event %d 0", num_device);
 		cuda_conversion_events_use[num_device][0] = 1;
 		if (Config->Debug && Config->VerboseTiming) cudaStreamSynchronize(cuda_command_queues[num_device][j]);
@@ -442,16 +448,21 @@ int caldgemm_cuda::DGEMM_prepare_backend(size_t k, int j, unsigned int num_devic
 		}
 
 		if (Config->Debug) fprintf(STD_OUT, "Transfer B to GPU: region %d x %d\n", (int) width, (int) height);
+#ifndef CALDGEMM_CUDA_CUBLAS
 		CHKRET(cudaMemcpy2DAsync(dest_buffer_tmp, width, src_ptr, pitch * sizeof(double), width, height, cudaMemcpyHostToDevice, cuda_command_queues[num_device][j]), "Copying B to device");
+#else
+		CHKRET(cudaMemcpy2DAsync(dest_image, width, src_ptr, pitch * sizeof(double), width, height, cudaMemcpyHostToDevice, cuda_command_queues[num_device][j]), "Copying B to device");
+#endif
 		if (Config->Debug && Config->VerboseTiming) cudaStreamSynchronize(cuda_command_queues[num_device][j]);
 
+#ifndef CALDGEMM_CUDA_CUBLAS
 		dim3 threads(GROUP_SIZE_X, GROUP_SIZE_Y), blocks(GROUP_COUNT_X, GROUP_COUNT_Y);
 		int arg_transpose = !TransposeB;
 		size_t arg_width = width / sizeof(double), arg_height = height;
 		if (Config->Debug) fprintf(STD_OUT, "Conversion Kernel B: x %d y %d\n", (int) arg_width, (int) arg_height);
 		CUDAConversionKernel <<<blocks, threads, 0, cuda_command_queues[num_device][j]>>> ((double*) dest_buffer_tmp, (double*) dest_image, arg_width, arg_height, arg_transpose);
 		CHKRET(cudaGetLastError(), "CUDA Conversion Kernel Execution");
-
+#endif
 		CHKRET(cudaEventRecord(cuda_conversion_events[num_device][1], cuda_command_queues[num_device][j]), "Recording event %d 1", num_device);
 		cuda_conversion_events_use[num_device][1] = 1;
 		if (Config->Debug && Config->VerboseTiming) cudaStreamSynchronize(cuda_command_queues[num_device][j]);


### PR DESCRIPTION
Removed tranpose because it creates a performance problem with overlapping copy and DGEMM kernels (the transpose kernel becomes blocked until previous DGEMM is almost finished, and then the Copy C HostToDevice is delayed so it cannot overlap DGEMM).  

Other possible solutions that could be investigated in the future:  
1.) change the order of operations, Copy C H2D first before calling transposes, (for example: copy A, copy B, copy C, transpose A, transpose B, DGEMM, copy C) then the copy will overlap with previous DGEMM.
2.) Use a "High Priority" cuda stream for transpose, so it will not wait for previous DGEMM thread blocks to be scheduled first.  

In my test this gives ~15% increased HPL performance.
